### PR TITLE
Debug canvas component length error

### DIFF
--- a/Client/src/components/builder/BuilderComponent.jsx
+++ b/Client/src/components/builder/BuilderComponent.jsx
@@ -14,10 +14,13 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
   };
 
   const renderComponent = () => {
+    // Handle both 'props' and 'properties' for backward compatibility
+    const componentProps = component.properties || component.props || {};
+    
     const commonStyles = {
       position: 'absolute',
-      left: component.position.x,
-      top: component.position.y,
+      left: component.position?.x || 0,
+      top: component.position?.y || 0,
       minWidth: '100px',
       minHeight: '30px',
       border: isSelected && !previewMode ? '2px solid #1976d2' : '1px solid transparent',
@@ -34,7 +37,7 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
               if (!previewMode) onSelect();
             }}
           >
-            {component.props.content || 'Sample text'}
+            {componentProps.content || 'Sample text'}
             {isSelected && !previewMode && (
               <IconButton
                 size="small"
@@ -48,7 +51,7 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
         );
 
       case 'heading':
-        const HeadingComponent = component.props.level || 'h1';
+        const HeadingComponent = componentProps.level || 'h1';
         return (
           <Box
             component={HeadingComponent}
@@ -58,7 +61,7 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
               if (!previewMode) onSelect();
             }}
           >
-            {component.props.content || 'Sample Heading'}
+            {componentProps.content || 'Sample Heading'}
             {isSelected && !previewMode && (
               <IconButton
                 size="small"
@@ -80,8 +83,8 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
               if (!previewMode) onSelect();
             }}
           >
-            <Button variant={component.props.variant || 'contained'}>
-              {component.props.text || 'Click Me'}
+            <Button variant={componentProps.variant || 'contained'}>
+              {componentProps.text || 'Click Me'}
             </Button>
             {isSelected && !previewMode && (
               <IconButton
@@ -105,8 +108,8 @@ const BuilderComponent = ({ component, isSelected, previewMode, onSelect }) => {
             }}
           >
             <img
-              src={component.props.src || 'https://via.placeholder.com/300x200'}
-              alt={component.props.alt || 'Sample Image'}
+              src={componentProps.src || 'https://via.placeholder.com/300x200'}
+              alt={componentProps.alt || 'Sample Image'}
               style={{ width: '100%', height: 'auto', display: 'block' }}
             />
             {isSelected && !previewMode && (

--- a/Client/src/components/builder/Canvas.jsx
+++ b/Client/src/components/builder/Canvas.jsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux';
 import { addComponent } from '../../redux/slices/builderSlice.js';
 import BuilderComponent from './BuilderComponent.jsx';
 
-const Canvas = ({ components, selectedComponent, previewMode, onSelectComponent }) => {
+const Canvas = ({ components = [], selectedComponent, previewMode, onSelectComponent }) => {
   const dispatch = useDispatch();
 
   const [{ isOver }, drop] = useDrop({
@@ -24,7 +24,7 @@ const Canvas = ({ components, selectedComponent, previewMode, onSelectComponent 
         dispatch(addComponent({
           type: item.type,
           position,
-          props: getDefaultProps(item.type),
+          properties: getDefaultProps(item.type),
         }));
       }
     },

--- a/Client/src/components/builder/PropertyPanel.jsx
+++ b/Client/src/components/builder/PropertyPanel.jsx
@@ -18,7 +18,7 @@ import { ExpandMore, ColorLens } from '@mui/icons-material';
 import { useDispatch } from 'react-redux';
 import { updateComponent } from '../../redux/slices/builderSlice.js';
 
-const PropertyPanel = ({ selectedComponent, components }) => {
+const PropertyPanel = ({ selectedComponent, components = [] }) => {
   const dispatch = useDispatch();
   const component = components.find(c => c.id === selectedComponent);
 
@@ -27,8 +27,8 @@ const PropertyPanel = ({ selectedComponent, components }) => {
       dispatch(updateComponent({
         id: component.id,
         updates: {
-          props: {
-            ...component.props,
+          properties: {
+            ...(component.properties || component.props || {}),
             [property]: value,
           },
         },
@@ -42,7 +42,7 @@ const PropertyPanel = ({ selectedComponent, components }) => {
         id: component.id,
         updates: {
           styles: {
-            ...component.styles,
+            ...(component.styles || {}),
             [property]: value,
           },
         },
@@ -59,6 +59,9 @@ const PropertyPanel = ({ selectedComponent, components }) => {
   }
 
   const renderPropertiesForType = () => {
+    // Handle both 'props' and 'properties' for backward compatibility
+    const componentProps = component.properties || component.props || {};
+    
     switch (component.type) {
       case 'text':
       case 'heading':
@@ -67,7 +70,7 @@ const PropertyPanel = ({ selectedComponent, components }) => {
             <TextField
               fullWidth
               label="Content"
-              value={component.props.content || ''}
+              value={componentProps.content || ''}
               onChange={(e) => handlePropertyChange('content', e.target.value)}
               multiline={component.type === 'text'}
               rows={component.type === 'text' ? 3 : 1}
@@ -77,7 +80,7 @@ const PropertyPanel = ({ selectedComponent, components }) => {
               <FormControl fullWidth sx={{ mb: 2 }}>
                 <InputLabel>Heading Level</InputLabel>
                 <Select
-                  value={component.props.level || 'h1'}
+                  value={componentProps.level || 'h1'}
                   onChange={(e) => handlePropertyChange('level', e.target.value)}
                 >
                   <MenuItem value="h1">H1</MenuItem>
@@ -98,14 +101,14 @@ const PropertyPanel = ({ selectedComponent, components }) => {
             <TextField
               fullWidth
               label="Button Text"
-              value={component.props.text || ''}
+              value={componentProps.text || ''}
               onChange={(e) => handlePropertyChange('text', e.target.value)}
               sx={{ mb: 2 }}
             />
             <FormControl fullWidth sx={{ mb: 2 }}>
               <InputLabel>Variant</InputLabel>
               <Select
-                value={component.props.variant || 'contained'}
+                                  value={componentProps.variant || 'contained'}
                 onChange={(e) => handlePropertyChange('variant', e.target.value)}
               >
                 <MenuItem value="contained">Contained</MenuItem>
@@ -122,14 +125,14 @@ const PropertyPanel = ({ selectedComponent, components }) => {
             <TextField
               fullWidth
               label="Image URL"
-              value={component.props.src || ''}
+              value={componentProps.src || ''}
               onChange={(e) => handlePropertyChange('src', e.target.value)}
               sx={{ mb: 2 }}
             />
             <TextField
               fullWidth
               label="Alt Text"
-              value={component.props.alt || ''}
+              value={componentProps.alt || ''}
               onChange={(e) => handlePropertyChange('alt', e.target.value)}
               sx={{ mb: 2 }}
             />

--- a/Client/src/pages/Builder.jsx
+++ b/Client/src/pages/Builder.jsx
@@ -40,7 +40,7 @@ import {
   redo,
   togglePreviewMode,
   updateCanvasSettings
-} from '../redux/slices/builderSlice'; // ✅ removed updateSettings and canvasSettings
+} from '../redux/slices/builderSlice';
 
 const DRAWER_WIDTH = 280;
 
@@ -49,14 +49,15 @@ const Builder = () => {
   const dispatch = useDispatch();
 
   const { 
-    components, 
-    selectedComponent, 
-    previewMode, 
-    saving, 
-    canvas 
-  } = useSelector(state => state.builder); // ✅ Added canvas here
+    canvas,
+    isPreviewMode
+  } = useSelector(state => state.builder);
 
-  const canvasSettings = canvas.canvasSettings; // ✅ Get settings
+  // Extract the correct data from the Redux state
+  const components = canvas.elements || [];
+  const selectedComponent = canvas.selectedElement;
+  const previewMode = isPreviewMode;
+  const canvasSettings = canvas.canvasSettings;
 
   const [viewportSize, setViewportSize] = useState('desktop');
   const [leftDrawerOpen, setLeftDrawerOpen] = useState(true);
@@ -69,9 +70,20 @@ const Builder = () => {
     desktop: { width: '100%', icon: Computer },
   };
 
-  const handleSave = () => {
-    // Implement save functionality
-    console.log('Saving project...', { components, canvasSettings });
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // Implement save functionality
+      console.log('Saving project...', { components, canvasSettings });
+      // Add actual save logic here
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
+    } catch (error) {
+      console.error('Save failed:', error);
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleExport = () => {


### PR DESCRIPTION
Fixes React runtime errors by aligning component props with Redux state and adding undefined checks.

The "Cannot read properties of undefined (reading 'length')" error was caused by components attempting to access properties of `undefined` objects. This PR resolves the issue by:
*   Correcting Redux state extraction in `Builder.jsx` to use `canvas.elements`.
*   Providing default empty array values for `components` props in `Canvas.jsx` and `PropertyPanel.jsx`.
*   Standardizing property access from `props` to `properties` across `Canvas.jsx`, `BuilderComponent.jsx`, and `PropertyPanel.jsx`, while maintaining backward compatibility.
*   Adding safety checks for potentially undefined properties (e.g., `component.position?.x || 0`).
*   Refactoring the `saving` state to be managed locally in `Builder.jsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-93ae5c49-c84d-4928-b941-b8074c6d32cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93ae5c49-c84d-4928-b941-b8074c6d32cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>